### PR TITLE
Automatically configure MYSQL_TABLE from spider name

### DIFF
--- a/scrapy_mysql_pipeline/pipeline.py
+++ b/scrapy_mysql_pipeline/pipeline.py
@@ -78,29 +78,11 @@ class MySQLPipeline(object):  #
         self.retries = self.settings.get('MYSQL_RETRIES', 3)
         self.close_on_error = self.settings.get('MYSQL_CLOSE_ON_ERROR', True)
         self.upsert = self.settings.get('MYSQL_UPSERT', False)
-        table_specifier = self.settings.get('MYSQL_TABLE', None)
-        if table_specifier is not None:
-            if '%' in table_specifier:
-                # Allow spider's name to be substituted using sprintf
-                self.get_table = lambda: table_specifier % self.spider.name
-            else:
-                # Table name is the same for all spiders
-                self.get_table = lambda: table_specifier
-        else:
-            # Default is to use the spider's name as the table name
-            self.get_table = lambda: self.spider.name
-
+        self.table = self.settings.get('MYSQL_TABLE', None)
         self.db = adbapi.ConnectionPool('pymysql', **db_args)
 
     def close_spider(self, spider):
         self.db.close()
-
-    def open_spider(self, spider):
-        self.spider = spider
-
-    @property
-    def table(self):
-        return self.get_table()
 
     @staticmethod
     def preprocess_item(item):

--- a/scrapy_mysql_pipeline/pipeline.py
+++ b/scrapy_mysql_pipeline/pipeline.py
@@ -78,11 +78,29 @@ class MySQLPipeline(object):  #
         self.retries = self.settings.get('MYSQL_RETRIES', 3)
         self.close_on_error = self.settings.get('MYSQL_CLOSE_ON_ERROR', True)
         self.upsert = self.settings.get('MYSQL_UPSERT', False)
-        self.table = self.settings.get('MYSQL_TABLE', None)
+        table_specifier = self.settings.get('MYSQL_TABLE', None)
+        if table_specifier is not None:
+            if '%' in table_specifier:
+                # Allow spider's name to be substituted using sprintf
+                self.get_table = lambda: table_specifier % self.spider.name
+            else:
+                # Table name is the same for all spiders
+                self.get_table = lambda: table_specifier
+        else:
+            # Default is to use the spider's name as the table name
+            self.get_table = lambda: self.spider.name
+
         self.db = adbapi.ConnectionPool('pymysql', **db_args)
 
     def close_spider(self, spider):
         self.db.close()
+
+    def open_spider(self, spider):
+        self.spider = spider
+
+    @property
+    def table(self):
+        return self.get_table()
 
     @staticmethod
     def preprocess_item(item):


### PR DESCRIPTION
If the setting `MYSQL_TABLE` is not defined, then the table-name is now generated from spider name.  Alternatively, `MYSQL_TABLE` can optionally contain a `'%s'` printf wildcard, which is replaced by the spider name.  These modifications allow a configuration in which multiple spiders within the same scrapy project use the same DB schema, but each spider populates a different table. 